### PR TITLE
Directory check in plugin manager.  Closes #6

### DIFF
--- a/Zumba/Symbiosis/Plugin/PluginManager.php
+++ b/Zumba/Symbiosis/Plugin/PluginManager.php
@@ -76,6 +76,10 @@ class PluginManager {
 	 */
 	protected static function buildPluginCache($path, $namespace) {
 		$classObjects = array();
+		if (!is_dir($path)) {
+			Log::write('Plugin path not a directory.', Log::LEVEL_WARNING, compact('path'));
+			return array();
+		}
 		if ($handle = \opendir($path)) {
 			while (false !== ($entry = \readdir($handle))) {
 				if ($entry === '.' || $entry === '..') {

--- a/Zumba/Symbiosis/Test/Plugin/PluginManagerTest.php
+++ b/Zumba/Symbiosis/Test/Plugin/PluginManagerTest.php
@@ -33,4 +33,13 @@ class PluginManagerTest extends TestCase {
 		$this->assertEquals($expectedList, $pluginList);
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testNonExistentPluginDirectory() {
+		PluginManager::loadPlugins('/some/non-existent/directory', 'Test');
+		$pluginList = PluginManager::getPluginList();
+		$this->assertEmpty($pluginList);
+	}
+
 }


### PR DESCRIPTION
Plugin manager now checks existence of specified directory and logs a warning when it doesn't exist.
