### PR TITLE
Updated Symbiosis to use SymbiosisEvent alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ PluginManager::loadPlugins(
 
 ```php
 <?php
-
-use \Zumba\Symbiosis\Event\Event;
+// always alias to SymbiosisEvent to avoid a namespace collision.
+use \Zumba\Symbiosis\Event\Event as SymbiosisEvent;
 
 // Somewhere in your app, trigger plugins listening to event
-$event = new Event('sample.someevent', array('ping' => 'pong'));
+$event = new SymbiosisEvent('sample.someevent', array('ping' => 'pong'));
 $event->trigger();
 ```
 

--- a/Zumba/Symbiosis/Event/EventManager.php
+++ b/Zumba/Symbiosis/Event/EventManager.php
@@ -12,7 +12,7 @@
  */
 namespace Zumba\Symbiosis\Event;
 
-use \Zumba\Symbiosis\Event\Event,
+use \Zumba\Symbiosis\Event\Event as SymbiosisEvent,
 	\Zumba\Symbiosis\Log,
 	\Zumba\Symbiosis\Exception;
 
@@ -60,7 +60,7 @@ class EventManager {
 	 * @param array $data Data to append/override in the event object
 	 * @return boolean
 	 */
-	public static function trigger(Event $event, $data = array()) {
+	public static function trigger(SymbiosisEvent $event, $data = array()) {
 		$eventName = $event->name();
 		$event->data(array_merge($event->data(), $data));
 		if (!isset(static::$registry[$eventName])) {

--- a/Zumba/Symbiosis/Test/Event/EventManagerTest.php
+++ b/Zumba/Symbiosis/Test/Event/EventManagerTest.php
@@ -14,7 +14,7 @@ namespace Zumba\Symbiosis\Test\Event;
 
 use \Zumba\Symbiosis\Test\TestCase,
 	\Zumba\Symbiosis\Event\EventManager,
-	\Zumba\Symbiosis\Event\Event;
+	\Zumba\Symbiosis\Event\Event as SymbiosisEvent;
 
 /**
  * @group event
@@ -40,8 +40,8 @@ class EventManagerTest extends TestCase {
 		EventManager::register('test.event1', array($testObject, 'testCallback2'));
 		EventManager::register('test.event2', array($testObject, 'testCallback2'));
 
-		$event1 = new Event('test.event1');
-		$event2 = new Event('test.event2');
+		$event1 = new SymbiosisEvent('test.event1');
+		$event2 = new SymbiosisEvent('test.event2');
 		$this->assertTrue($event1->trigger());
 		$this->assertTrue($event2->trigger());
 	}
@@ -55,7 +55,7 @@ class EventManagerTest extends TestCase {
 	}
 
 	public function testTriggerWithNoListener() {
-		$event = new Event('test.event1');
+		$event = new SymbiosisEvent('test.event1');
 		$this->assertFalse($event->trigger());
 	}
 
@@ -65,7 +65,7 @@ class EventManagerTest extends TestCase {
 			->method('testCallback1');
 		EventManager::register('test.event1', array($testObject, 'testCallback1'));
 		EventManager::clear('test.event1');
-		$event = new Event('test.event1');
+		$event = new SymbiosisEvent('test.event1');
 		$event->trigger();
 	}
 
@@ -73,8 +73,8 @@ class EventManagerTest extends TestCase {
 		$testObject = $this->getMock('stdClass', array('testCallback1'));
 		$testObject->expects($this->never())
 			->method('testCallback1');
-		$event = new Event('test.event1');
-		EventManager::register('test.event1', function(Event $event) {
+		$event = new SymbiosisEvent('test.event1');
+		EventManager::register('test.event1', function(SymbiosisEvent $event) {
 			return false;
 		});
 		EventManager::register('test.event1', array($testObject, 'testCallback1'));
@@ -85,8 +85,8 @@ class EventManagerTest extends TestCase {
 		$testObject = $this->getMock('stdClass', array('testCallback1'));
 		$testObject->expects($this->never())
 			->method('testCallback1');
-		$event = new Event('test.event1');
-		EventManager::register('test.event1', function(Event $event) {
+		$event = new SymbiosisEvent('test.event1');
+		EventManager::register('test.event1', function(SymbiosisEvent $event) {
 			$event->stopPropagation();
 		});
 		EventManager::register('test.event1', array($testObject, 'testCallback1'));
@@ -98,15 +98,15 @@ class EventManagerTest extends TestCase {
 		$testObject->expects($this->once())
 			->method('testCallback1');
 		EventManager::register('test.event1', array($testObject, 'testCallback1'));
-		$event = new Event('test.event1');
+		$event = new SymbiosisEvent('test.event1');
 		$event->trigger();
 		$event->name('test.event2');
 		$event->trigger();
 	}
 
 	public function testSuggestingPreventAction() {
-		$event = new Event('test.event1');
-		EventManager::register('test.event1', function(Event $event) {
+		$event = new SymbiosisEvent('test.event1');
+		EventManager::register('test.event1', function(SymbiosisEvent $event) {
 			$event->preventAction();
 		});
 		$event->trigger();
@@ -114,8 +114,8 @@ class EventManagerTest extends TestCase {
 	}
 
 	public function testSuggestingPreventActionWithMessage() {
-		$event = new Event('test.event1');
-		EventManager::register('test.event1', function(Event $event) {
+		$event = new SymbiosisEvent('test.event1');
+		EventManager::register('test.event1', function(SymbiosisEvent $event) {
 			$event->preventAction(true, 'Reason why should prevent.');
 		});
 		$event->trigger();
@@ -125,19 +125,19 @@ class EventManagerTest extends TestCase {
 
 	public function testEventPriority() {
 		// lower priority
-		$lowPriority = function(Event $event) {
+		$lowPriority = function(SymbiosisEvent $event) {
 			EventManagerTest::$order[] = 3;
 		};
-		$highPriority = function(Event $event) {
+		$highPriority = function(SymbiosisEvent $event) {
 			EventManagerTest::$order[] = 1;
 		};
-		$alsoHighPriority = function(Event $event) {
+		$alsoHighPriority = function(SymbiosisEvent $event) {
 			EventManagerTest::$order[] = 2;
 		};
 		EventManager::register('test.event1', $lowPriority, EventManager::PRIORITY_LOW);
 		EventManager::register('test.event1', $highPriority, EventManager::PRIORITY_HIGH);
 		EventManager::register('test.event1', $alsoHighPriority, EventManager::PRIORITY_HIGH);
-		$event = new Event('test.event1');
+		$event = new SymbiosisEvent('test.event1');
 		$event->trigger();
 		$this->assertEquals(array(1, 2, 3), static::$order);
 	}

--- a/Zumba/Symbiosis/Test/Event/EventTest.php
+++ b/Zumba/Symbiosis/Test/Event/EventTest.php
@@ -14,7 +14,7 @@ namespace Zumba\Symbiosis\Test\Event;
 
 use \Zumba\Symbiosis\Test\TestCase,
 	\Zumba\Symbiosis\Event\EventManager,
-	\Zumba\Symbiosis\Event\Event;
+	\Zumba\Symbiosis\Event\Event as SymbiosisEvent;
 
 /**
  * @group event
@@ -30,7 +30,7 @@ class EventTest extends TestCase {
 		$data = array(
 			'package' => true
 		);
-		$event = new Event('test', $data);
+		$event = new SymbiosisEvent('test', $data);
 		$this->assertEquals(array('package' => true), $event->data());
 		$event->data(array('package2' => true));
 		$this->assertEquals(array('package2' => true), $event->data());
@@ -40,7 +40,7 @@ class EventTest extends TestCase {
 		$data = array(
 			'package' => true
 		);
-		$event = new Event('test', $data);
+		$event = new SymbiosisEvent('test', $data);
 		$this->assertEquals(array('package' => true), $event->data());
 		$data2 = array(
 			'package2' => true


### PR DESCRIPTION
Symbiosis is now using the alias, and the readme now mentions the namespace collision issue.
