### PR TITLE
Stop calling stopPropagation on every triggered event.

### DIFF
--- a/src/Event/EventRegistry.php
+++ b/src/Event/EventRegistry.php
@@ -99,7 +99,6 @@ class EventRegistry implements ListenerProviderInterface, EventDispatcherInterfa
                 break;
             }
         }
-        $event->stopPropagation();
         return true;
     }
 


### PR DESCRIPTION
The PSR-14 refactor included a call to `stopPropagation` on all events after their listeners were executed.  We can't find that requirement in the PSR-14 docs, and it causes BC issues with some of our user-land code, so I'm removing it.